### PR TITLE
Fix crash on no default set

### DIFF
--- a/scripts/color-selector.js
+++ b/scripts/color-selector.js
@@ -99,7 +99,7 @@ H5PEditor.widgets.colorSelector = H5PEditor.ColorSelector = (function ($) {
    */
   ColorSelector.prototype.validate = function () {
     this.hide();
-    return (this.params.length !== 0);
+    return (this.params !== undefined && this.params.length !== 0);
   };
 
   ColorSelector.prototype.remove = function () {};


### PR DESCRIPTION
There may be use cases where no default value should be set in
semantics.json. In that case validation will crash because params
is undefined.