### PR TITLE
HFP-4287 Fix use of spectrum parameter allowEmpty

### DIFF
--- a/scripts/color-selector.js
+++ b/scripts/color-selector.js
@@ -107,7 +107,12 @@ H5PEditor.widgets.colorSelector = H5PEditor.ColorSelector = (function ($) {
    */
   ColorSelector.prototype.validate = function () {
     this.hide();
-    return (this.params !== undefined && this.params.length !== 0);
+
+    if (this.field.spectrum.allowEmpty && this.params === null || this.params === '') {
+      return true;
+    }
+
+    return (this.params && this.params.length !== 0);
   };
 
   ColorSelector.prototype.remove = function () {};


### PR DESCRIPTION
The spectrum library provides an `allowEmpty` parameter (cmp. https://bgrins.github.io/spectrum/#options) and this color picker explicitly deals with `null` values when setting the color (cmp. https://github.com/h5p/h5p-editor-color-selector/blob/master/scripts/color-selector.js#L92), but this will currently crash in validation if `params` is `null` (cmp. https://github.com/h5p/h5p-editor-color-selector/blob/master/scripts/color-selector.js#L110).

Fixed the validation here.